### PR TITLE
Removing left padding from breadcrumb

### DIFF
--- a/documentation/source/changelog/0.1.4.rst
+++ b/documentation/source/changelog/0.1.4.rst
@@ -1,0 +1,8 @@
+0.1.4: CSS Updates 
+==================
+Updated by Harsha Kokel
+
+Layout Changes 🚧
+
+* Removing left padding from breadcrumb in ``theme.css`` to align it with the rest of the page. 
+

--- a/starling_theme/static/css/theme.css
+++ b/starling_theme/static/css/theme.css
@@ -64,6 +64,11 @@ li.masthead__menu-item {
 }
 
 /* Breadcrumb navigation */
+
+.wy-breadcrumbs{
+  padding-left: 0;
+}
+
 .wy-breadcrumbs li {
   font-size: 22px;
   display: inline-block;


### PR DESCRIPTION
The left padding in the breadcrumb felt out of order. So removing that padding.